### PR TITLE
feat: list and resume conversations

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,17 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
+### Resume existing chat
+
+List your existing conversations and choose one to continue:
+
+```bash
+python examples/select_chat.py
+```
+
+Use the numeric menu to pick a conversation from the list and the script will
+resume that chat.
+
 ## More Examples
 
 For a more complex example, check out the [examples](/examples) folder in the repository.

--- a/examples/select_chat.py
+++ b/examples/select_chat.py
@@ -1,0 +1,74 @@
+"""Select and resume an existing ChatGPT conversation.
+
+This example lists all available conversations and lets the user choose one
+to continue. It works with both synchronous and asynchronous clients.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from typing import List, Dict
+
+from re_gpt import SyncChatGPT, AsyncChatGPT
+
+# Replace with your own session token
+SESSION_TOKEN = "__Secure-next-auth.session-token here"
+
+
+def choose_conversation(conversations: List[Dict]) -> str:
+    """Prompt the user to select a conversation from ``conversations``."""
+
+    for idx, conv in enumerate(conversations, start=1):
+        title = conv.get("title") or "(no title)"
+        print(f"{idx}. {title}")
+
+    choice = int(input("Select a conversation: "))
+    return conversations[choice - 1]["id"]
+
+
+def run_sync() -> None:
+    with SyncChatGPT(session_token=SESSION_TOKEN) as chatgpt:
+        conversations = chatgpt.list_all_conversations()
+        conversation_id = choose_conversation(conversations)
+        conversation = chatgpt.get_conversation(conversation_id)
+
+        while True:
+            prompt = input("user: ")
+            for message in conversation.chat(prompt):
+                print(message["content"], end="", flush=True)
+            print()
+
+
+async def run_async() -> None:
+    async with AsyncChatGPT(session_token=SESSION_TOKEN) as chatgpt:
+        conversations = await chatgpt.list_all_conversations()
+        conversation_id = choose_conversation(conversations)
+        conversation = chatgpt.get_conversation(conversation_id)
+
+        while True:
+            prompt = input("user: ")
+            async for message in conversation.chat(prompt):
+                print(message["content"], end="", flush=True)
+            print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--async", action="store_true", dest="use_async", help="Use AsyncChatGPT"
+    )
+    args = parser.parse_args()
+
+    if args.use_async:
+        if sys.version_info >= (3, 8) and sys.platform.lower().startswith("win"):
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+        asyncio.run(run_async())
+    else:
+        run_sync()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/re_gpt/async_chatgpt.py
+++ b/re_gpt/async_chatgpt.py
@@ -608,6 +608,40 @@ class AsyncChatGPT:
 
         return response.json()
 
+    async def list_all_conversations(self, limit: int = 28) -> list[dict]:
+        """Asynchronously retrieve metadata for all conversations.
+
+        Args:
+            limit: Maximum number of conversations to fetch per request.
+
+        Returns:
+            List of dictionaries containing ``id``, ``title`` and
+            ``last_updated`` for each conversation.
+        """
+
+        conversations: list[dict] = []
+        offset = 0
+
+        while True:
+            data = await self.retrieve_chats(offset=offset, limit=limit)
+            items = data.get("items", [])
+
+            for item in items:
+                conversations.append(
+                    {
+                        "id": item.get("id"),
+                        "title": item.get("title"),
+                        "last_updated": item.get("update_time"),
+                    }
+                )
+
+            if len(items) < limit:
+                break
+
+            offset += limit
+
+        return conversations
+
     async def check_websocket_availability(self) -> bool:
         """
         Check if WebSocket is available.

--- a/re_gpt/sync_chatgpt.py
+++ b/re_gpt/sync_chatgpt.py
@@ -529,6 +529,40 @@ class SyncChatGPT(AsyncChatGPT):
         )
 
         return response.json()
+
+    def list_all_conversations(self, limit: int = 28) -> list[dict]:
+        """Retrieve metadata for all conversations.
+
+        Args:
+            limit: Maximum number of conversations to fetch per request.
+
+        Returns:
+            List of dictionaries containing ``id``, ``title`` and
+            ``last_updated`` for each conversation.
+        """
+
+        conversations: list[dict] = []
+        offset = 0
+
+        while True:
+            data = self.retrieve_chats(offset=offset, limit=limit)
+            items = data.get("items", [])
+
+            for item in items:
+                conversations.append(
+                    {
+                        "id": item.get("id"),
+                        "title": item.get("title"),
+                        "last_updated": item.get("update_time"),
+                    }
+                )
+
+            if len(items) < limit:
+                break
+
+            offset += limit
+
+        return conversations
     
     def check_websocket_availability(self) -> bool:
         """


### PR DESCRIPTION
## Summary
- add `list_all_conversations` to sync and async clients to page through chat history
- provide `examples/select_chat.py` for resuming a chosen conversation
- document resuming chats via conversation selector script

## Testing
- `python -m py_compile re_gpt/sync_chatgpt.py re_gpt/async_chatgpt.py examples/select_chat.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afb2fd6b3483229d267eeda6469b2a