### PR TITLE
docs: add interactive conversation resume example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
     <li><a href="#usage">Usage</a>
         <ul>
         <li><a href="#basic-example">Example Usage</a></li>
+        <li><a href="#resume-a-previous-conversation-interactively">Resume a previous conversation interactively</a></li>
         </ul>
     </li>
     <li><a href="#roadmap">Roadmap</a></li>
@@ -109,6 +110,29 @@ with SyncChatGPT(session_token=session_token) as chatgpt:
         print(message["content"], flush=True, end="")
 
 ```
+
+### Resume a previous conversation interactively
+
+```python
+from re_gpt import SyncChatGPT
+
+session_token = "__Secure-next-auth.session-token here"
+
+with SyncChatGPT(session_token=session_token) as chatgpt:
+    conversations = chatgpt.list_all_conversations()
+    for idx, conv in enumerate(conversations):
+        print(f"{idx}: {conv['title']}")
+
+    selected = int(input("Select conversation number: "))
+    conversation = chatgpt.get_conversation(conversations[selected]["id"])
+
+    prompt = input("Enter your prompt: ")
+    for message in conversation.chat(prompt):
+        print(message["content"], flush=True, end="")
+```
+
+See [examples/select_chat.py](examples/select_chat.py) for the full script.
+
 
 ### Basic async example
 

--- a/examples/select_chat.py
+++ b/examples/select_chat.py
@@ -1,0 +1,18 @@
+from re_gpt import SyncChatGPT
+
+# consts
+session_token = "__Secure-next-auth.session-token here"
+
+# Create ChatGPT instance using the session token
+with SyncChatGPT(session_token=session_token) as chatgpt:
+    conversations = chatgpt.list_all_conversations()
+
+    for idx, conv in enumerate(conversations):
+        print(f"{idx}: {conv['title']}")
+
+    selected = int(input("Select conversation number: "))
+    conversation = chatgpt.get_conversation(conversations[selected]["id"])
+
+    prompt = input("Enter your prompt: ")
+    for message_chunk in conversation.chat(prompt):
+        print(message_chunk["content"], flush=True, end="")


### PR DESCRIPTION
## Summary
- add example for resuming a previous conversation interactively
- link to new example script for selecting a chat by index

## Testing
- `python -m py_compile examples/select_chat.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afb2ff273883228d4724b612944ecf