### PR TITLE
Rename retrieve_chats to list_conversations_page

### DIFF
--- a/re_gpt/async_chatgpt.py
+++ b/re_gpt/async_chatgpt.py
@@ -593,9 +593,18 @@ class AsyncChatGPT:
 
         return response.json()
 
-    async def retrieve_chats(
+    async def list_conversations_page(
         self, offset: Optional[int] = 0, limit: Optional[int] = 28
     ) -> dict:
+        """Retrieve a single page of conversations.
+
+        Args:
+            offset (Optional[int]): Starting index of the page.
+            limit (Optional[int]): Maximum number of conversations to return.
+
+        Returns:
+            dict: JSON response containing one page of conversations.
+        """
         params = {
             "offset": offset,
             "limit": limit,

--- a/re_gpt/sync_chatgpt.py
+++ b/re_gpt/sync_chatgpt.py
@@ -515,9 +515,18 @@ class SyncChatGPT(AsyncChatGPT):
 
         return response.json()
 
-    def retrieve_chats(
+    def list_conversations_page(
         self, offset: Optional[int] = 0, limit: Optional[int] = 28
     ) -> dict:
+        """Retrieve a single page of conversations.
+
+        Args:
+            offset (Optional[int]): Starting index of the page.
+            limit (Optional[int]): Maximum number of conversations to return.
+
+        Returns:
+            dict: JSON response containing one page of conversations.
+        """
         params = {
             "offset": offset,
             "limit": limit,


### PR DESCRIPTION
## Summary
- rename `retrieve_chats` to `list_conversations_page` in async and sync clients
- document that the method returns a single page of conversation results

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afb3033dfc8322a55a92772a3d8493