### PR TITLE
feat: update ChatGPT domain

### DIFF
--- a/re_gpt/async_chatgpt.py
+++ b/re_gpt/async_chatgpt.py
@@ -22,8 +22,8 @@ from .utils import async_get_binary_path, get_model_slug
 
 # Constants
 USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36"
-CHATGPT_API = "https://chat.openai.com/backend-api/{}"
-CHATGPT_FREE_API = "https://chat.openai.com/backend-anon/{}"
+CHATGPT_API = "https://chatgpt.com/backend-api/{}"
+CHATGPT_FREE_API = "https://chatgpt.com/backend-anon/{}"
 BACKUP_ARKOSE_TOKEN_GENERATOR = "https://arkose-token-generator.zaieem.repl.co/token"
 WS_REGISTER_URL = CHATGPT_API.format("register-websocket")
 
@@ -477,8 +477,8 @@ class AsyncChatGPT:
             "Accept-Language": "en-US",
             "Accept-Encoding": "gzip, deflate, br",
             "Content-Type": "application/json",
-            "Origin": "https://chat.openai.com",
-            "Alt-Used": "chat.openai.com",
+            "Origin": "https://chatgpt.com",
+            "Alt-Used": "chatgpt.com",
             "Connection": "keep-alive",
             "Oai-device-id": self.devive_id,
         }
@@ -536,14 +536,14 @@ class AsyncChatGPT:
 
         Returns: authentication token.
         """
-        url = "https://chat.openai.com/api/auth/session"
+        url = "https://chatgpt.com/api/auth/session"
         cookies = {"__Secure-next-auth.session-token": self.session_token}
 
         headers = {
             "User-Agent": USER_AGENT,
             "Accept": "*/*",
             "Accept-Language": "en-US,en;q=0.5",
-            "Alt-Used": "chat.openai.com",
+            "Alt-Used": "chatgpt.com",
             "Connection": "keep-alive",
             "Sec-Fetch-Dest": "empty",
             "Sec-Fetch-Mode": "cors",
@@ -736,12 +736,12 @@ class AsyncChatGPT:
         return token
 
     async def fetch_free_mode_cookies(self):
-        home_url = "https://chat.openai.com/"
+        home_url = "https://chatgpt.com/"
         headers = {
             "User-Agent": USER_AGENT,
             "Accept": "*/*",
             "Accept-Language": "en-US,en;q=0.5",
-            "Alt-Used": "chat.openai.com",
+            "Alt-Used": "chatgpt.com",
             "Connection": "keep-alive",
             "Sec-Fetch-Dest": "empty",
             "Sec-Fetch-Mode": "cors",

--- a/re_gpt/sync_chatgpt.py
+++ b/re_gpt/sync_chatgpt.py
@@ -458,14 +458,14 @@ class SyncChatGPT(AsyncChatGPT):
 
         Returns: authentication token.
         """
-        url = "https://chat.openai.com/api/auth/session"
+        url = "https://chatgpt.com/api/auth/session"
         cookies = {"__Secure-next-auth.session-token": self.session_token}
 
         headers = {
             "User-Agent": USER_AGENT,
             "Accept": "*/*",
             "Accept-Language": "en-US,en;q=0.5",
-            "Alt-Used": "chat.openai.com",
+            "Alt-Used": "chatgpt.com",
             "Connection": "keep-alive",
             "Sec-Fetch-Dest": "empty",
             "Sec-Fetch-Mode": "cors",
@@ -655,12 +655,12 @@ class SyncChatGPT(AsyncChatGPT):
         return token
 
     def fetch_free_mode_cookies(self):
-        home_url = "https://chat.openai.com/"
+        home_url = "https://chatgpt.com/"
         headers = {
             "User-Agent": USER_AGENT,
             "Accept": "*/*",
             "Accept-Language": "en-US,en;q=0.5",
-            "Alt-Used": "chat.openai.com",
+            "Alt-Used": "chatgpt.com",
             "Connection": "keep-alive",
             "Sec-Fetch-Dest": "empty",
             "Sec-Fetch-Mode": "cors",


### PR DESCRIPTION
## Summary
- switch to https://chatgpt.com for web endpoints
- update auth and free-mode calls to new domain

## Testing
- `pytest`
- `flake8 re_gpt/async_chatgpt.py re_gpt/sync_chatgpt.py` *(fails: command not found and installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68afbbc87c5c832295342c6f01c4f276