### PR TITLE
Replace chat.openai.com references with chatgpt.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ This can be useful if you want to use ChatGPT API without a [ChatGPT Plus](https
 
 ### Inspiration
 
-ChatGPT has an official API which can be used to interface your Python code to it, but it needs to be used with an API key. This API key can only be obtained if you have a [ChatGPT Plus](https://openai.com/blog/chatgpt-plus) account, which requires $20/month (as of 05/11/2023). But you can use ChatGPT for free, using the [ChatGPT web interface](https://chat.openai.com/). This project aims to interface your code to ChatGPT web version so you can use ChatGPT in your Python code without using an API key.
+ChatGPT has an official API which can be used to interface your Python code to it, but it needs to be used with an API key. This API key can only be obtained if you have a [ChatGPT Plus](https://openai.com/blog/chatgpt-plus) account, which requires $20/month (as of 05/11/2023). But you can use ChatGPT for free, using the [ChatGPT web interface](https://chatgpt.com/). This project aims to interface your code to ChatGPT web version so you can use ChatGPT in your Python code without using an API key.
 
 ### How it works
 
-[ChatGPT](https://chat.openai.com/) web interface's requests have been reverse engineered, and directly integrated into Python requests. Hence, any requests made using this script is a simulated as a request made by a user directly on the website. Hence, it is free and needs no API key.
+[ChatGPT](https://chatgpt.com/) web interface's requests have been reverse engineered, and directly integrated into Python requests. Hence, any requests made using this script is a simulated as a request made by a user directly on the website. Hence, it is free and needs no API key.
 
 ### Built Using
 
@@ -183,7 +183,7 @@ For a more complex example, check out the [examples](/examples) folder in the re
 
 ### Obtaining The Session Token
 
-1. Go to <https://chat.openai.com/chat> and log in or sign up.
+1. Go to <https://chatgpt.com/chat> and log in or sign up.
 2. Open the developer tools in your browser.
 3. Go to the `Application` tab and open the `Cookies` section.
 4. Copy the value for `__Secure-next-auth.session-token` and save it.

--- a/docs/zh-README.md
+++ b/docs/zh-README.md
@@ -63,11 +63,11 @@
 
 ### 灵感来源
 
-ChatGPT有一个官方API，可以用于将您的Python代码与之接口，但它需要使用API密钥。这个API密钥只能通过拥有[ChatGPT Plus](https://openai.com/blog/chatgpt-plus)账户获得，这需要20美元/月（截至2023年5月11日）。但是，您可以通过使用[ChatGPT网页界面](https://chat.openai.com/)免费使用ChatGPT。本项目旨在将您的代码与ChatGPT网页版本接口，这样您就可以在不使用API密钥的情况下在Python代码中使用ChatGPT。
+ChatGPT有一个官方API，可以用于将您的Python代码与之接口，但它需要使用API密钥。这个API密钥只能通过拥有[ChatGPT Plus](https://openai.com/blog/chatgpt-plus)账户获得，这需要20美元/月（截至2023年5月11日）。但是，您可以通过使用[ChatGPT网页界面](https://chatgpt.com/)免费使用ChatGPT。本项目旨在将您的代码与ChatGPT网页版本接口，这样您就可以在不使用API密钥的情况下在Python代码中使用ChatGPT。
 
 ### 工作原理
 
-[ChatGPT](https://chat.openai.com/)网页界面的请求已经被反向工程，并直接集成到Python请求中。因此，使用此脚本进行的任何请求都模拟为用户直接在网站上进行的请求。因此，它是免费的，不需要API密钥。
+[ChatGPT](https://chatgpt.com/)网页界面的请求已经被反向工程，并直接集成到Python请求中。因此，使用此脚本进行的任何请求都模拟为用户直接在网站上进行的请求。因此，它是免费的，不需要API密钥。
 
 ### 构建使用
 
@@ -147,7 +147,7 @@ if __name__ == "__main__":
 
 ### 获取会话令牌
 
-1. 访问<https://chat.openai.com/chat>并登录或注册。
+1. 访问<https://chatgpt.com/chat>并登录或注册。
 2. 打开浏览器的开发者工具。
 3. 转到`Application`标签页并打开`Cookies`部分。
 4. 复制`__Secure-next-auth.session-token`的值并保存。

--- a/examples/async_complex_example.py
+++ b/examples/async_complex_example.py
@@ -75,4 +75,4 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 
-# Note: The 'conversation_id' will be found in the chat's url: 'https://chat.openai.com/c/conversation_id'
+# Note: The 'conversation_id' will be found in the chat's url: 'https://chatgpt.com/c/conversation_id'

--- a/examples/complex_example.py
+++ b/examples/complex_example.py
@@ -69,4 +69,4 @@ def main():
 if __name__ == "__main__":
     main()
 
-# Note: The 'conversation_id' will be found in the chat's url: 'https://chat.openai.com/c/conversation_id'
+# Note: The 'conversation_id' will be found in the chat's url: 'https://chatgpt.com/c/conversation_id'

--- a/re_gpt/async_chatgpt.py
+++ b/re_gpt/async_chatgpt.py
@@ -22,8 +22,8 @@ from .utils import async_get_binary_path, get_model_slug
 
 # Constants
 USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36"
-CHATGPT_API = "https://chat.openai.com/backend-api/{}"
-CHATGPT_FREE_API = "https://chat.openai.com/backend-anon/{}"
+CHATGPT_API = "https://chatgpt.com/backend-api/{}"
+CHATGPT_FREE_API = "https://chatgpt.com/backend-anon/{}"
 BACKUP_ARKOSE_TOKEN_GENERATOR = "https://arkose-token-generator.zaieem.repl.co/token"
 WS_REGISTER_URL = CHATGPT_API.format("register-websocket")
 
@@ -477,8 +477,8 @@ class AsyncChatGPT:
             "Accept-Language": "en-US",
             "Accept-Encoding": "gzip, deflate, br",
             "Content-Type": "application/json",
-            "Origin": "https://chat.openai.com",
-            "Alt-Used": "chat.openai.com",
+            "Origin": "https://chatgpt.com",
+            "Alt-Used": "chatgpt.com",
             "Connection": "keep-alive",
             "Oai-device-id": self.devive_id,
         }
@@ -536,14 +536,14 @@ class AsyncChatGPT:
 
         Returns: authentication token.
         """
-        url = "https://chat.openai.com/api/auth/session"
+        url = "https://chatgpt.com/api/auth/session"
         cookies = {"__Secure-next-auth.session-token": self.session_token}
 
         headers = {
             "User-Agent": USER_AGENT,
             "Accept": "*/*",
             "Accept-Language": "en-US,en;q=0.5",
-            "Alt-Used": "chat.openai.com",
+            "Alt-Used": "chatgpt.com",
             "Connection": "keep-alive",
             "Sec-Fetch-Dest": "empty",
             "Sec-Fetch-Mode": "cors",
@@ -736,12 +736,12 @@ class AsyncChatGPT:
         return token
 
     async def fetch_free_mode_cookies(self):
-        home_url = "https://chat.openai.com/"
+        home_url = "https://chatgpt.com/"
         headers = {
             "User-Agent": USER_AGENT,
             "Accept": "*/*",
             "Accept-Language": "en-US,en;q=0.5",
-            "Alt-Used": "chat.openai.com",
+            "Alt-Used": "chatgpt.com",
             "Connection": "keep-alive",
             "Sec-Fetch-Dest": "empty",
             "Sec-Fetch-Mode": "cors",

--- a/re_gpt/sync_chatgpt.py
+++ b/re_gpt/sync_chatgpt.py
@@ -458,14 +458,14 @@ class SyncChatGPT(AsyncChatGPT):
 
         Returns: authentication token.
         """
-        url = "https://chat.openai.com/api/auth/session"
+        url = "https://chatgpt.com/api/auth/session"
         cookies = {"__Secure-next-auth.session-token": self.session_token}
 
         headers = {
             "User-Agent": USER_AGENT,
             "Accept": "*/*",
             "Accept-Language": "en-US,en;q=0.5",
-            "Alt-Used": "chat.openai.com",
+            "Alt-Used": "chatgpt.com",
             "Connection": "keep-alive",
             "Sec-Fetch-Dest": "empty",
             "Sec-Fetch-Mode": "cors",
@@ -655,12 +655,12 @@ class SyncChatGPT(AsyncChatGPT):
         return token
 
     def fetch_free_mode_cookies(self):
-        home_url = "https://chat.openai.com/"
+        home_url = "https://chatgpt.com/"
         headers = {
             "User-Agent": USER_AGENT,
             "Accept": "*/*",
             "Accept-Language": "en-US,en;q=0.5",
-            "Alt-Used": "chat.openai.com",
+            "Alt-Used": "chatgpt.com",
             "Connection": "keep-alive",
             "Sec-Fetch-Dest": "empty",
             "Sec-Fetch-Mode": "cors",


### PR DESCRIPTION
## Summary
- update async and sync ChatGPT clients to point at chatgpt.com endpoints
- refresh README, docs, and examples to reference chatgpt.com instead of chat.openai.com

## Testing
- `pytest`
- `rg 'chat\.openai\.com'`


------
https://chatgpt.com/codex/tasks/task_e_68afbbcc04dc8322afcad45121edb845