### PR TITLE
refactor select_chat imports

### DIFF
--- a/examples/select_chat.py
+++ b/examples/select_chat.py
@@ -1,35 +1,17 @@
-from re_gpt import SyncChatGPT
+from __future__ import annotations
 
-# consts
-session_token = "__Secure-next-auth.session-token here"
-
-# Create ChatGPT instance using the session token
-with SyncChatGPT(session_token=session_token) as chatgpt:
-    conversations = chatgpt.list_all_conversations()
-
-    for idx, conv in enumerate(conversations):
-        print(f"{idx}: {conv['title']}")
-
-    selected = int(input("Select conversation number: "))
-    conversation = chatgpt.get_conversation(conversations[selected]["id"])
-
-    prompt = input("Enter your prompt: ")
-    for message_chunk in conversation.chat(prompt):
-        print(message_chunk["content"], flush=True, end="")
 """Select and resume an existing ChatGPT conversation.
 
 This example lists all available conversations and lets the user choose one
 to continue. It works with both synchronous and asynchronous clients.
 """
 
-from __future__ import annotations
-
 import argparse
 import asyncio
 import sys
-from typing import List, Dict
+from typing import Dict, List
 
-from re_gpt import SyncChatGPT, AsyncChatGPT
+from re_gpt import AsyncChatGPT, SyncChatGPT
 
 # Replace with your own session token
 SESSION_TOKEN = "__Secure-next-auth.session-token here"


### PR DESCRIPTION
## Summary
- remove outdated code from `select_chat` example
- move `from __future__ import annotations` to file start and regroup imports

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afc274bcd083228efc8aa6e87a519b