### PR TITLE
feat: externalize session token configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ config.ini
 test.py
 *.sublime-project
 *.sublime-workspace
+.chatgpt_session

--- a/README.md
+++ b/README.md
@@ -88,13 +88,18 @@ pip install re-gpt
 ```
 
 ## Usage
+Before running the examples, store your session token in a configuration file.
+Copy `config.example.ini` to `config.ini` and replace the token value, or create
+`~/.chatgpt_session` containing only your token. The helper
+`re_gpt.config.get_session_token()` reads the token from these locations.
 
 ### Basic example
 
 ```python
 from re_gpt import SyncChatGPT
+from re_gpt.config import get_session_token
 
-session_token = "__Secure-next-auth.session-token here"
+session_token = get_session_token()
 conversation_id = None # conversation ID here
 
 
@@ -115,8 +120,9 @@ with SyncChatGPT(session_token=session_token) as chatgpt:
 
 ```python
 from re_gpt import SyncChatGPT
+from re_gpt.config import get_session_token
 
-session_token = "__Secure-next-auth.session-token here"
+session_token = get_session_token()
 
 with SyncChatGPT(session_token=session_token) as chatgpt:
     conversations = chatgpt.list_all_conversations()
@@ -141,9 +147,10 @@ import asyncio
 import sys
 
 from re_gpt import AsyncChatGPT
+from re_gpt.config import get_session_token
 
-session_token = "__Secure-next-auth.session-token here"
-conversation_id = conversation_id = None # conversation ID here
+session_token = get_session_token()
+conversation_id = None # conversation ID here
 
 if sys.version_info >= (3, 8) and sys.platform.lower().startswith("win"):
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
@@ -187,6 +194,7 @@ For a more complex example, check out the [examples](/examples) folder in the re
 2. Open the developer tools in your browser.
 3. Go to the `Application` tab and open the `Cookies` section for `https://chatgpt.com`.
 4. Copy the value for `__Secure-next-auth.session-token` from the `chatgpt.com` cookies and save it.
+5. Save the token in `config.ini` (based on `config.example.ini`) or in `~/.chatgpt_session` so the examples can load it automatically.
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ pip install re-gpt
 ```
 
 ## Usage
-Before running the examples, store your session token in a configuration file.
-Copy `config.example.ini` to `config.ini` and replace the token value, or create
-`~/.chatgpt_session` containing only your token. The helper
-`re_gpt.config.get_session_token()` reads the token from these locations.
+
+All examples load the session token with `get_session_token()`, which looks
+for a `config.ini` file in the working directory or a `~/.chatgpt_session`
+file containing the token.
 
 ### Basic example
 
@@ -100,7 +100,7 @@ from re_gpt import SyncChatGPT
 from re_gpt.config import get_session_token
 
 session_token = get_session_token()
-conversation_id = None # conversation ID here
+conversation_id = None  # conversation ID here
 
 
 with SyncChatGPT(session_token=session_token) as chatgpt:
@@ -150,7 +150,7 @@ from re_gpt import AsyncChatGPT
 from re_gpt.config import get_session_token
 
 session_token = get_session_token()
-conversation_id = None # conversation ID here
+conversation_id = conversation_id = None # conversation ID here
 
 if sys.version_info >= (3, 8) and sys.platform.lower().startswith("win"):
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
@@ -194,7 +194,7 @@ For a more complex example, check out the [examples](/examples) folder in the re
 2. Open the developer tools in your browser.
 3. Go to the `Application` tab and open the `Cookies` section for `https://chatgpt.com`.
 4. Copy the value for `__Secure-next-auth.session-token` from the `chatgpt.com` cookies and save it.
-5. Save the token in `config.ini` (based on `config.example.ini`) or in `~/.chatgpt_session` so the examples can load it automatically.
+5. Store the token in a `config.ini` file (see `config.example.ini`) or in `~/.chatgpt_session`.
 
 ## TODO
 

--- a/config.example.ini
+++ b/config.example.ini
@@ -1,6 +1,3 @@
 [session]
-# Replace the value below with your own session token from ChatGPT
-# https://chatgpt.com/ cookies (__Secure-next-auth.session-token)
 token = __Secure-next-auth.session-token here
-# Optionally specify a conversation to resume
-conversation_id =
+conversation_id = 

--- a/config.example.ini
+++ b/config.example.ini
@@ -1,0 +1,6 @@
+[session]
+# Replace the value below with your own session token from ChatGPT
+# https://chatgpt.com/ cookies (__Secure-next-auth.session-token)
+token = __Secure-next-auth.session-token here
+# Optionally specify a conversation to resume
+conversation_id =

--- a/docs/zh-README.md
+++ b/docs/zh-README.md
@@ -87,9 +87,7 @@ pip install re-gpt
 
 ## 使用方法
 
-在运行示例之前，请将会话令牌保存到配置文件中。将 `config.example.ini`
-复制为 `config.ini` 并替换其中的令牌值，或者在家目录创建一个仅包含令牌的
-`~/.chatgpt_session` 文件。`re_gpt.config.get_session_token()` 会从这些位置读取令牌。
+所有示例通过 `get_session_token()` 自动加载会话令牌，该函数会在工作目录下的 `config.ini` 文件或 `~/.chatgpt_session` 文件中查找。
 
 ### 简单示例
 
@@ -157,7 +155,7 @@ if __name__ == "__main__":
 2. 打开浏览器的开发者工具。
 3. 转到`Application`标签页并打开 `https://chatgpt.com` 的 `Cookies` 部分。
 4. 从 `chatgpt.com` 的 `Cookies` 中复制`__Secure-next-auth.session-token`的值并保存。
-5. 将令牌保存到 `config.ini`（基于 `config.example.ini`）或 `~/.chatgpt_session`，示例会自动读取。
+5. 将令牌保存到工作目录下的 `config.ini`（参见 `config.example.ini`）或 `~/.chatgpt_session` 文件中。
 
 ## 待办事项
 

--- a/docs/zh-README.md
+++ b/docs/zh-README.md
@@ -87,12 +87,17 @@ pip install re-gpt
 
 ## 使用方法
 
+在运行示例之前，请将会话令牌保存到配置文件中。将 `config.example.ini`
+复制为 `config.ini` 并替换其中的令牌值，或者在家目录创建一个仅包含令牌的
+`~/.chatgpt_session` 文件。`re_gpt.config.get_session_token()` 会从这些位置读取令牌。
+
 ### 简单示例
 
 ``` python
 from re_gpt import SyncChatGPT
+from re_gpt.config import get_session_token
 
-session_token = "__Secure-next-auth.session-token here"
+session_token = get_session_token()
 conversation_id = None # 这里填写对话ID
 
 
@@ -116,8 +121,9 @@ import asyncio
 import sys
 
 from re_gpt import AsyncChatGPT
+from re_gpt.config import get_session_token
 
-session_token = "__Secure-next-auth.session-token here"
+session_token = get_session_token()
 conversation_id = None # 这里填写对话ID
 
 if sys.version_info >= (3, 8) and sys.platform.lower().startswith("win"):
@@ -151,6 +157,7 @@ if __name__ == "__main__":
 2. 打开浏览器的开发者工具。
 3. 转到`Application`标签页并打开 `https://chatgpt.com` 的 `Cookies` 部分。
 4. 从 `chatgpt.com` 的 `Cookies` 中复制`__Secure-next-auth.session-token`的值并保存。
+5. 将令牌保存到 `config.ini`（基于 `config.example.ini`）或 `~/.chatgpt_session`，示例会自动读取。
 
 ## 待办事项
 

--- a/examples/async_basic_example.py
+++ b/examples/async_basic_example.py
@@ -2,9 +2,10 @@ import asyncio
 import sys
 
 from re_gpt import AsyncChatGPT
+from re_gpt.config import get_session_token
 
 # consts
-session_token = "__Secure-next-auth.session-token here"
+session_token = get_session_token()
 conversation_id = None  # Set it to the conversation ID if you want to continue an existing chat or None to create a new chat
 
 # If the Python version is 3.8 or higher and the platform is Windows, set the event loop policy

--- a/examples/async_complex_example.py
+++ b/examples/async_complex_example.py
@@ -3,6 +3,7 @@ import configparser
 import sys
 
 from re_gpt import AsyncChatGPT
+from re_gpt.config import get_session_token
 
 # Load configuration from 'config.ini'
 config = configparser.ConfigParser()
@@ -36,7 +37,7 @@ def print_chat(chat):
 async def main():
     async with AsyncChatGPT(
         # proxies=None,  # Optional proxies for network requests
-        session_token=chat_session["token"],  # Use the session token for authentication
+        session_token=get_session_token(),  # Use the session token for authentication
     ) as chatgpt:
         if chat_session["conversation_id"]:
             conversation = chatgpt.get_conversation(chat_session["conversation_id"])

--- a/examples/async_complex_example.py
+++ b/examples/async_complex_example.py
@@ -9,6 +9,7 @@ from re_gpt.config import get_session_token
 config = configparser.ConfigParser()
 config.read("config.ini")
 chat_session = config["session"]
+session_token = get_session_token()
 
 # ANSI color codes for console text formatting
 GREEN = "\033[92m"
@@ -37,7 +38,7 @@ def print_chat(chat):
 async def main():
     async with AsyncChatGPT(
         # proxies=None,  # Optional proxies for network requests
-        session_token=get_session_token(),  # Use the session token for authentication
+        session_token=session_token,  # Use the session token for authentication
     ) as chatgpt:
         if chat_session["conversation_id"]:
             conversation = chatgpt.get_conversation(chat_session["conversation_id"])

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -1,7 +1,8 @@
 from re_gpt import SyncChatGPT
+from re_gpt.config import get_session_token
 
 # consts
-session_token = "__Secure-next-auth.session-token here"
+session_token = get_session_token()
 conversation_id = None  # Set it to the conversation ID if you want to continue an existing chat or None to create a new chat
 
 # Create ChatGPT instance using the session token

--- a/examples/complex_example.py
+++ b/examples/complex_example.py
@@ -1,6 +1,7 @@
 import configparser
 
 from re_gpt import SyncChatGPT
+from re_gpt.config import get_session_token
 
 # Load configuration from 'config.ini'
 config = configparser.ConfigParser()
@@ -30,7 +31,7 @@ def print_chat(chat):
 def main():
     with SyncChatGPT(
         # proxies=None,  # Optional proxies for network requests
-        session_token=chat_session["token"],  # Use the session token for authentication
+        session_token=get_session_token(),  # Use the session token for authentication
     ) as chatgpt:
         if chat_session["conversation_id"]:
             conversation = chatgpt.get_conversation(chat_session["conversation_id"])

--- a/examples/complex_example.py
+++ b/examples/complex_example.py
@@ -7,6 +7,7 @@ from re_gpt.config import get_session_token
 config = configparser.ConfigParser()
 config.read("config.ini")
 chat_session = config["session"]
+session_token = get_session_token()
 
 # ANSI color codes for console text formatting
 GREEN = "\033[92m"
@@ -31,7 +32,7 @@ def print_chat(chat):
 def main():
     with SyncChatGPT(
         # proxies=None,  # Optional proxies for network requests
-        session_token=get_session_token(),  # Use the session token for authentication
+        session_token=session_token,  # Use the session token for authentication
     ) as chatgpt:
         if chat_session["conversation_id"]:
             conversation = chatgpt.get_conversation(chat_session["conversation_id"])

--- a/examples/select_chat.py
+++ b/examples/select_chat.py
@@ -1,21 +1,3 @@
-from re_gpt import SyncChatGPT
-
-# consts
-session_token = "__Secure-next-auth.session-token here"
-
-# Create ChatGPT instance using the session token
-with SyncChatGPT(session_token=session_token) as chatgpt:
-    conversations = chatgpt.list_all_conversations()
-
-    for idx, conv in enumerate(conversations):
-        print(f"{idx}: {conv['title']}")
-
-    selected = int(input("Select conversation number: "))
-    conversation = chatgpt.get_conversation(conversations[selected]["id"])
-
-    prompt = input("Enter your prompt: ")
-    for message_chunk in conversation.chat(prompt):
-        print(message_chunk["content"], flush=True, end="")
 """Select and resume an existing ChatGPT conversation.
 
 This example lists all available conversations and lets the user choose one
@@ -27,17 +9,16 @@ from __future__ import annotations
 import argparse
 import asyncio
 import sys
-from typing import List, Dict
+from typing import Dict, List
 
 from re_gpt import SyncChatGPT, AsyncChatGPT
+from re_gpt.config import get_session_token
 
-# Replace with your own session token
-SESSION_TOKEN = "__Secure-next-auth.session-token here"
+SESSION_TOKEN = get_session_token()
 
 
 def choose_conversation(conversations: List[Dict]) -> str:
     """Prompt the user to select a conversation from ``conversations``."""
-
     for idx, conv in enumerate(conversations, start=1):
         title = conv.get("title") or "(no title)"
         print(f"{idx}. {title}")
@@ -89,4 +70,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/re_gpt/config.py
+++ b/re_gpt/config.py
@@ -1,0 +1,51 @@
+"""Utility helpers for loading the ChatGPT session token."""
+
+from __future__ import annotations
+
+import configparser
+from pathlib import Path
+from typing import Optional
+
+
+DEFAULT_CONFIG_PATHS = [Path("config.ini"), Path.home() / ".chatgpt_session"]
+
+
+def get_session_token(path: Optional[str] = None) -> str:
+    """Return the ChatGPT session token.
+
+    The token can be stored either as plain text in a file or inside an INI
+    file under ``[session]`` with the key ``token``. If ``path`` is ``None``,
+    the function searches the default locations ``config.ini`` in the current
+    working directory and ``~/.chatgpt_session``.
+
+    Args:
+        path: Optional path to the configuration file.
+
+    Returns:
+        The session token as a string.
+
+    Raises:
+        FileNotFoundError: If no suitable configuration file is found.
+        KeyError: If the configuration file does not contain the token.
+    """
+
+    paths = [Path(path).expanduser()] if path else DEFAULT_CONFIG_PATHS
+
+    for cfg_path in paths:
+        if not cfg_path.exists():
+            continue
+
+        if cfg_path.suffix in {".ini", ".cfg"}:
+            parser = configparser.ConfigParser()
+            parser.read(cfg_path)
+            try:
+                return parser["session"]["token"].strip()
+            except KeyError as exc:
+                raise KeyError("Session token not found in config file") from exc
+        else:
+            return cfg_path.read_text().strip()
+
+    raise FileNotFoundError(
+        "No session token file found. Provide a path or create config.ini or "
+        "~/.chatgpt_session",
+    )

--- a/sampleconfig.ini
+++ b/sampleconfig.ini
@@ -1,3 +1,0 @@
-[session]
-token = __Secure-next-auth.session-token here
-conversation_id =


### PR DESCRIPTION
## Summary
- add `get_session_token` helper that loads the ChatGPT session token from `config.ini` or `~/.chatgpt_session`
- update examples to fetch the token via the helper
- document token configuration and provide `config.example.ini`

## Testing
- `python -m py_compile re_gpt/config.py examples/basic_example.py examples/async_basic_example.py examples/complex_example.py examples/async_complex_example.py examples/select_chat.py`


------
https://chatgpt.com/codex/tasks/task_e_68afc27725e883229636d8c8f67ae4fd