### PR TITLE
Improve auth token retrieval robustness

### DIFF
--- a/re_gpt/async_chatgpt.py
+++ b/re_gpt/async_chatgpt.py
@@ -558,12 +558,19 @@ class AsyncChatGPT:
         }
 
         response = await self.session.get(url=url, headers=headers)
+        try:
+            response.raise_for_status()
+        except Exception as e:
+            raise InvalidSessionToken from e
         response_json = response.json()
 
-        if "accessToken" in response_json:
-            return response_json["accessToken"]
+        access_token = response_json.get("accessToken")
+        if access_token:
+            return access_token
 
-        raise InvalidSessionToken
+        raise UnexpectedResponseError(
+            "accessToken missing in auth response", response.text
+        )
 
     async def set_custom_instructions(
         self,

--- a/re_gpt/sync_chatgpt.py
+++ b/re_gpt/sync_chatgpt.py
@@ -480,12 +480,19 @@ class SyncChatGPT(AsyncChatGPT):
         }
 
         response = self.session.get(url=url, headers=headers)
+        try:
+            response.raise_for_status()
+        except Exception as e:
+            raise InvalidSessionToken from e
         response_json = response.json()
 
-        if "accessToken" in response_json:
-            return response_json["accessToken"]
+        access_token = response_json.get("accessToken")
+        if access_token:
+            return access_token
 
-        raise InvalidSessionToken
+        raise UnexpectedResponseError(
+            "accessToken missing in auth response", response.text
+        )
 
     def set_custom_instructions(
         self,


### PR DESCRIPTION
## Summary
- Ensure HTTP responses succeed before parsing when fetching auth tokens
- Provide descriptive error when `accessToken` is missing from auth response

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afc364c66483229cd84902f767c41e