### PR TITLE
Add helper for loading ChatGPT session token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,7 @@ funcaptcha_bin
 .vscode
 test/
 config.ini
+.chatgpt_session
 test.py
 *.sublime-project
 *.sublime-workspace

--- a/README.md
+++ b/README.md
@@ -90,13 +90,14 @@ pip install re-gpt
 
 ### Configuration
 
-Copy `sampleconfig.ini` to `config.ini` and update the placeholder values:
+Copy `config.example.ini` to `config.ini` and update the placeholder values or
+store your token in a `~/.chatgpt_session` file:
 
 ```sh
-cp sampleconfig.ini config.ini
+cp config.example.ini config.ini
 ```
 
-Edit `config.ini` and replace `token` with your ChatGPT session token and `conversation_id` with the ID of an existing conversation if you want to resume one.
+Edit `config.ini` and replace `token` with your ChatGPT session token and `conversation_id` with the ID of an existing conversation if you want to resume one. If a `config.ini` is not found, `get_session_token` will look for a token in `~/.chatgpt_session` instead.
 
 ## Usage
 
@@ -104,8 +105,9 @@ Edit `config.ini` and replace `token` with your ChatGPT session token and `conve
 
 ```python
 from re_gpt import SyncChatGPT
+from re_gpt.utils import get_session_token
 
-session_token = "__Secure-next-auth.session-token here"
+session_token = get_session_token()
 conversation_id = None # conversation ID here
 
 
@@ -126,8 +128,9 @@ with SyncChatGPT(session_token=session_token) as chatgpt:
 
 ```python
 from re_gpt import SyncChatGPT
+from re_gpt.utils import get_session_token
 
-session_token = "__Secure-next-auth.session-token here"
+session_token = get_session_token()
 
 with SyncChatGPT(session_token=session_token) as chatgpt:
     conversations = chatgpt.list_all_conversations()
@@ -152,8 +155,9 @@ import asyncio
 import sys
 
 from re_gpt import AsyncChatGPT
+from re_gpt.utils import get_session_token
 
-session_token = "__Secure-next-auth.session-token here"
+session_token = get_session_token()
 conversation_id = conversation_id = None # conversation ID here
 
 if sys.version_info >= (3, 8) and sys.platform.lower().startswith("win"):

--- a/config.example.ini
+++ b/config.example.ini
@@ -1,5 +1,6 @@
 # Sample configuration for re_gpt.
 # Copy this file to config.ini and replace the placeholders with your own values.
+# Alternatively, you can store your session token in a ~/.chatgpt_session file.
 
 [session]
 # Authentication token from your ChatGPT account cookies.

--- a/docs/zh-README.md
+++ b/docs/zh-README.md
@@ -91,8 +91,9 @@ pip install re-gpt
 
 ``` python
 from re_gpt import SyncChatGPT
+from re_gpt.utils import get_session_token
 
-session_token = "__Secure-next-auth.session-token here"
+session_token = get_session_token()
 conversation_id = None # 这里填写对话ID
 
 
@@ -116,8 +117,9 @@ import asyncio
 import sys
 
 from re_gpt import AsyncChatGPT
+from re_gpt.utils import get_session_token
 
-session_token = "__Secure-next-auth.session-token here"
+session_token = get_session_token()
 conversation_id = None # 这里填写对话ID
 
 if sys.version_info >= (3, 8) and sys.platform.lower().startswith("win"):

--- a/examples/async_basic_example.py
+++ b/examples/async_basic_example.py
@@ -2,9 +2,10 @@ import asyncio
 import sys
 
 from re_gpt import AsyncChatGPT
+from re_gpt.utils import get_session_token
 
 # consts
-session_token = "__Secure-next-auth.session-token here"
+session_token = get_session_token()
 conversation_id = None  # Set it to the conversation ID if you want to continue an existing chat or None to create a new chat
 
 # If the Python version is 3.8 or higher and the platform is Windows, set the event loop policy

--- a/examples/async_complex_example.py
+++ b/examples/async_complex_example.py
@@ -3,11 +3,13 @@ import configparser
 import sys
 
 from re_gpt import AsyncChatGPT
+from re_gpt.utils import get_session_token
 
 # Load configuration from 'config.ini'
 config = configparser.ConfigParser()
 config.read("config.ini")
 chat_session = config["session"]
+session_token = get_session_token()
 
 # ANSI color codes for console text formatting
 GREEN = "\033[92m"
@@ -36,7 +38,7 @@ def print_chat(chat):
 async def main():
     async with AsyncChatGPT(
         # proxies=None,  # Optional proxies for network requests
-        session_token=chat_session["token"],  # Use the session token for authentication
+        session_token=session_token,  # Use the session token for authentication
     ) as chatgpt:
         if chat_session["conversation_id"]:
             conversation = chatgpt.get_conversation(chat_session["conversation_id"])

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -1,7 +1,8 @@
 from re_gpt import SyncChatGPT
+from re_gpt.utils import get_session_token
 
 # consts
-session_token = "__Secure-next-auth.session-token here"
+session_token = get_session_token()
 conversation_id = None  # Set it to the conversation ID if you want to continue an existing chat or None to create a new chat
 
 # Create ChatGPT instance using the session token

--- a/examples/complex_example.py
+++ b/examples/complex_example.py
@@ -1,11 +1,13 @@
 import configparser
 
 from re_gpt import SyncChatGPT
+from re_gpt.utils import get_session_token
 
 # Load configuration from 'config.ini'
 config = configparser.ConfigParser()
 config.read("config.ini")
 chat_session = config["session"]
+session_token = get_session_token()
 
 # ANSI color codes for console text formatting
 GREEN = "\033[92m"
@@ -30,7 +32,7 @@ def print_chat(chat):
 def main():
     with SyncChatGPT(
         # proxies=None,  # Optional proxies for network requests
-        session_token=chat_session["token"],  # Use the session token for authentication
+        session_token=session_token,  # Use the session token for authentication
     ) as chatgpt:
         if chat_session["conversation_id"]:
             conversation = chatgpt.get_conversation(chat_session["conversation_id"])

--- a/examples/select_chat.py
+++ b/examples/select_chat.py
@@ -12,9 +12,10 @@ import sys
 from typing import Dict, List
 
 from re_gpt import AsyncChatGPT, SyncChatGPT
+from re_gpt.utils import get_session_token
 
 # Replace with your own session token
-SESSION_TOKEN = "__Secure-next-auth.session-token here"
+SESSION_TOKEN = get_session_token()
 
 
 def choose_conversation(conversations: List[Dict]) -> str:


### PR DESCRIPTION
## Summary
- add `get_session_token` utility to read ChatGPT credentials from `config.ini` or `~/.chatgpt_session`
- update examples and docs to use the centralized helper and reference `config.example.ini`
- ignore local token files in `.gitignore`

## Testing
- `python -m py_compile re_gpt/utils.py examples/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68afc6a726348322a1eeea105aa4a44a