### PR TITLE
Fix conversation pagination and add tests

### DIFF
--- a/re_gpt/async_chatgpt.py
+++ b/re_gpt/async_chatgpt.py
@@ -639,7 +639,7 @@ class AsyncChatGPT:
         offset = 0
 
         while True:
-            data = await self.retrieve_chats(offset=offset, limit=limit)
+            data = await self.list_conversations_page(offset=offset, limit=limit)
             items = data.get("items", [])
 
             for item in items:

--- a/re_gpt/sync_chatgpt.py
+++ b/re_gpt/sync_chatgpt.py
@@ -561,7 +561,7 @@ class SyncChatGPT(AsyncChatGPT):
         offset = 0
 
         while True:
-            data = self.retrieve_chats(offset=offset, limit=limit)
+            data = self.list_conversations_page(offset=offset, limit=limit)
             items = data.get("items", [])
 
             for item in items:

--- a/tests/test_list_all_conversations.py
+++ b/tests/test_list_all_conversations.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import asyncio
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from re_gpt.sync_chatgpt import SyncChatGPT
+from re_gpt.async_chatgpt import AsyncChatGPT
+
+
+def test_sync_list_all_conversations_pagination(monkeypatch):
+    client = SyncChatGPT()
+
+    pages = [
+        {
+            "items": [
+                {"id": "1", "title": "a", "update_time": 1},
+                {"id": "2", "title": "b", "update_time": 2},
+            ]
+        },
+        {"items": [{"id": "3", "title": "c", "update_time": 3}]},
+    ]
+    calls = []
+
+    def fake_page(offset=0, limit=28):
+        calls.append((offset, limit))
+        return pages.pop(0)
+
+    monkeypatch.setattr(client, "list_conversations_page", fake_page)
+
+    result = client.list_all_conversations(limit=2)
+
+    assert result == [
+        {"id": "1", "title": "a", "last_updated": 1},
+        {"id": "2", "title": "b", "last_updated": 2},
+        {"id": "3", "title": "c", "last_updated": 3},
+    ]
+    assert calls == [(0, 2), (2, 2)]
+
+
+def test_async_list_all_conversations_pagination(monkeypatch):
+    client = AsyncChatGPT()
+
+    pages = [
+        {
+            "items": [
+                {"id": "1", "title": "a", "update_time": 1},
+                {"id": "2", "title": "b", "update_time": 2},
+            ]
+        },
+        {"items": [{"id": "3", "title": "c", "update_time": 3}]},
+    ]
+    calls = []
+
+    async def fake_page(offset=0, limit=28):
+        calls.append((offset, limit))
+        return pages.pop(0)
+
+    monkeypatch.setattr(client, "list_conversations_page", fake_page)
+
+    result = asyncio.run(client.list_all_conversations(limit=2))
+
+    assert result == [
+        {"id": "1", "title": "a", "last_updated": 1},
+        {"id": "2", "title": "b", "last_updated": 2},
+        {"id": "3", "title": "c", "last_updated": 3},
+    ]
+    assert calls == [(0, 2), (2, 2)]


### PR DESCRIPTION
## Summary
- Use `list_conversations_page` when listing all conversations in sync and async clients
- Ensure async pagination awaits the page fetch
- Add unit tests validating pagination aggregation for both sync and async clients

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afcd89e5a083229c3cfe443fbdd669