### PR TITLE
Add pagination to conversation selection example

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,14 +183,15 @@ if __name__ == "__main__":
 
 ### Resume existing chat
 
-List your existing conversations and choose one to continue:
+Page through your existing conversations and choose one to continue:
 
 ```bash
-python examples/select_chat.py
+python examples/select_chat.py --limit 5
 ```
 
-Use the numeric menu to pick a conversation from the list and the script will
-resume that chat.
+Use the numeric menu to pick a conversation from the current page.  Press
+`n` for the next page, `p` for the previous page or `q` to quit.  Fetched
+metadata is written to `conversations.json`.
 
 ## More Examples
 


### PR DESCRIPTION
## Summary
- paginate existing conversation lists using `list_conversations_page`
- allow navigation with next/previous commands and persist fetched metadata
- document pagination workflow in `select_chat.py` and README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afd3af2ccc83228048feeda7eb7cda