### PR TITLE
Handle unknown model slugs

### DIFF
--- a/re_gpt/async_chatgpt.py
+++ b/re_gpt/async_chatgpt.py
@@ -63,9 +63,16 @@ class AsyncConversation:
             chat = response.json()
             self.parent_id = list(chat.get("mapping", {}))[-1]
             model_slug = get_model_slug(chat)
-            self.model = [
-                key for key, value in MODELS.items() if value["slug"] == model_slug
-            ][0]
+            self.model = next(
+                (
+                    key
+                    for key, value in MODELS.items()
+                    if value["slug"] == model_slug
+                ),
+                None,
+            )
+            if self.model is None:
+                self.model = model_slug
         except Exception as e:
             error = e
         if error is not None:
@@ -256,6 +263,9 @@ class AsyncConversation:
         if self.conversation_id and (self.parent_id is None or self.model is None):
             await self.fetch_chat()  # it will automatically fetch the chat and set the parent id
 
+        if self.model not in MODELS:
+            raise InvalidModelName(self.model, MODELS)
+
         payload = {
             "conversation_mode": {"conversation_mode": {"kind": "primary_assistant"}},
             "conversation_id": self.conversation_id,
@@ -292,6 +302,9 @@ class AsyncConversation:
         Returns:
             dict: Payload containing message information for continuation.
         """
+        if self.model not in MODELS:
+            raise InvalidModelName(self.model, MODELS)
+
         payload = {
             "conversation_mode": {"conversation_mode": {"kind": "primary_assistant"}},
             "action": "continue",


### PR DESCRIPTION
## Summary
- Prevent `fetch_chat` from failing when encountering an unknown model slug
- Validate model availability when building request payloads and raise `InvalidModelName` if unsupported

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afe9969efc83228d0057b18b5ffa2e