### PR TITLE
Handle unknown model slugs

### DIFF
--- a/examples/select_chat.py
+++ b/examples/select_chat.py
@@ -47,11 +47,13 @@ def _extract_messages(chat: Dict) -> List[Dict]:
         content_parts = msg.get("content", {}).get("parts") or []
         if not content_parts:
             continue
+        # ``create_time`` is sometimes ``None`` for system messages; fallback to ``0``
+        # so that sorting works and these messages appear first.
         messages.append(
             {
                 "role": msg.get("author", {}).get("role", ""),
                 "content": content_parts[0],
-                "create_time": msg.get("create_time", 0),
+                "create_time": msg.get("create_time") or 0,
             }
         )
     messages.sort(key=lambda m: m["create_time"])

--- a/re_gpt/async_chatgpt.py
+++ b/re_gpt/async_chatgpt.py
@@ -63,9 +63,16 @@ class AsyncConversation:
             chat = response.json()
             self.parent_id = list(chat.get("mapping", {}))[-1]
             model_slug = get_model_slug(chat)
-            self.model = [
-                key for key, value in MODELS.items() if value["slug"] == model_slug
-            ][0]
+            self.model = next(
+                (
+                    key
+                    for key, value in MODELS.items()
+                    if value["slug"] == model_slug
+                ),
+                None,
+            )
+            if self.model is None:
+                self.model = model_slug
         except Exception as e:
             error = e
         if error is not None:
@@ -256,6 +263,9 @@ class AsyncConversation:
         if self.conversation_id and (self.parent_id is None or self.model is None):
             await self.fetch_chat()  # it will automatically fetch the chat and set the parent id
 
+        if self.model not in MODELS:
+            raise InvalidModelName(self.model, MODELS)
+
         payload = {
             "conversation_mode": {"conversation_mode": {"kind": "primary_assistant"}},
             "conversation_id": self.conversation_id,
@@ -292,6 +302,9 @@ class AsyncConversation:
         Returns:
             dict: Payload containing message information for continuation.
         """
+        if self.model not in MODELS:
+            raise InvalidModelName(self.model, MODELS)
+
         payload = {
             "conversation_mode": {"conversation_mode": {"kind": "primary_assistant"}},
             "action": "continue",

--- a/tests/test_select_chat.py
+++ b/tests/test_select_chat.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+
+def test_extract_messages_handles_none_create_time():
+    # Provide a dummy session token so importing the example does not fail
+    config = Path("config.ini")
+    config.write_text("[session]\ntoken=dummy\n")
+    try:
+        from examples.select_chat import _extract_messages
+    finally:
+        # Clean up the temporary config file
+        config.unlink()
+
+    chat = {
+        "mapping": {
+            "1": {
+                "message": {
+                    "author": {"role": "system"},
+                    "content": {"parts": ["System message"]},
+                    "create_time": None,
+                }
+            },
+            "2": {
+                "message": {
+                    "author": {"role": "user"},
+                    "content": {"parts": ["User message"]},
+                    "create_time": 100,
+                }
+            },
+        }
+    }
+
+    messages = _extract_messages(chat)
+    assert messages[0]["create_time"] == 0
+    assert [m["content"] for m in messages] == ["System message", "User message"]


### PR DESCRIPTION
## Summary
- Prevent `fetch_chat` from failing when encountering an unknown model slug
- Validate model availability when building request payloads and raise `InvalidModelName` if unsupported
- Default missing `create_time` values to zero when sorting messages in `select_chat`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afe9969efc83228d0057b18b5ffa2e